### PR TITLE
Fixed if statements in group_info_by_name method

### DIFF
--- a/lib/breacan/client/groups.rb
+++ b/lib/breacan/client/groups.rb
@@ -58,8 +58,7 @@ module Breacan
       end
 
       def groups_info_by_name(name)
-        res = groups_list
-        res.groups.find { |ch| ch['name'] == name } if res.ok
+        groups_list.find { |ch| ch['name'] == name }
       end
     end
   end

--- a/lib/breacan/version.rb
+++ b/lib/breacan/version.rb
@@ -1,3 +1,3 @@
 module Breacan
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
Hi, The following errors occurred while processing groups_info_by_name method.

```
[3] pry(main)> Breacan.groups_info_by_name('group_member')
NoMethodError: undefined method `ok' for #<Array:0x007f9d7f3997b0>
from /Users/myname/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/breacan-0.1.1/lib/breacan/client/groups.rb:62:in `groups_info_by_name'
```

so, I fixed this error by fixed if statements. 
