### PR TITLE
use chat.postMessage instead of chat.getMessage

### DIFF
--- a/lib/breacan/client/chat.rb
+++ b/lib/breacan/client/chat.rb
@@ -6,7 +6,7 @@ module Breacan
       end
 
       def chat_post_message(args)
-        get 'chat.getMessage', query: args
+        get 'chat.postMessage', query: args
       end
 
       def chat_update(args)


### PR DESCRIPTION
It is needless replacement of https://github.com/linyows/breacan/commit/b4b7dcb0cb3e8dab2e6f88919a50af118aff60e5
