### PR TITLE
fix warning of adapter setting position

### DIFF
--- a/lib/breacan/configurable.rb
+++ b/lib/breacan/configurable.rb
@@ -64,8 +64,8 @@ module Breacan
                 end
 
       builder.new do |c|
-        c.adapter Faraday.default_adapter
         c.response :breacan_custom
+        c.adapter Faraday.default_adapter
       end
     end
 


### PR DESCRIPTION
Fix following warning.

> WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.