### PR TITLE
unlock active support

### DIFF
--- a/breacan.gemspec
+++ b/breacan.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "sawyer", "~> 0.6"
-  spec.add_dependency "activesupport", "~>4.2"
+  spec.add_dependency "activesupport"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 

--- a/lib/breacan/client.rb
+++ b/lib/breacan/client.rb
@@ -62,7 +62,13 @@ module Breacan
           r = request :get, url, parse_query_and_convenience_headers(options.merge({cursor: nextc}))
           if r.is_a?(Sawyer::Resource)
             res ||= {}
-            res.to_hash.deep_merge!(r.to_hash)
+            res = res.deep_merge(r) do |key, this_val, other_val|
+              if this_val.is_a?(Array) && other_val.is_a?(Array)
+                this_val + other_val
+              else
+                other_val
+              end
+            end
           elsif r.is_a?(Array)
             res ||= []
             res.concat(r)


### PR DESCRIPTION
refs: https://github.com/slack-ruby/slack-ruby-client/blob/master/slack-ruby-client.gemspec#L20

一緒に利用するslack-ruby-clientと依存衝突するため、ロックしない。