### PR TITLE
fix: `Faraday::Response::Middleware` is no longer used.

### DIFF
--- a/lib/breacan/response/custom.rb
+++ b/lib/breacan/response/custom.rb
@@ -7,7 +7,7 @@ module Breacan
     # ref: https://github.com/lostisland/faraday/blob/c9cc1b30ecebcd57beffa67d275f68742b5b05c5/UPGRADING.md?plain=1#L128
     middleware_base = defined?(Faraday::Response::Middleware) ? Faraday::Response::Middleware : Faraday::Middleware
 
-    class Custom < Faraday::Response::Middleware
+    class Custom < middleware_base
       private
 
       def on_complete(res)

--- a/lib/breacan/response/custom.rb
+++ b/lib/breacan/response/custom.rb
@@ -3,6 +3,10 @@ require 'breacan/error'
 
 module Breacan
   module Response
+    # NOTE: Since faraday v.2, `Faraday::Response::Middleware` has been removed. We can use `Faraday::Middleware` instead.
+    # ref: https://github.com/lostisland/faraday/blob/c9cc1b30ecebcd57beffa67d275f68742b5b05c5/UPGRADING.md?plain=1#L128
+    middleware_base = defined?(Faraday::Response::Middleware) ? Faraday::Response::Middleware : Faraday::Middleware
+
     class Custom < Faraday::Response::Middleware
       private
 


### PR DESCRIPTION
## Background
`Faraday::Response::Middleware` is no longer used. We must use `Faraday::Middleware` instead.
ref: https://github.com/lostisland/faraday/blob/c9cc1b30ecebcd57beffa67d275f68742b5b05c5/UPGRADING.md?plain=1#L128

> Remove `Faraday::Response::Middleware`. You can now use the new `on_complete` callback provided by `Faraday::Middleware`.

ref: Removed in this PR([Autoloading, dependency loading and middleware registry cleanup](https://github.com/lostisland/faraday/pull/1301/files#top))

Before this change, I cannot use [rake_notification](https://github.com/mizoR/rake_notification).
The error is below.

```ruby
[1] pry(main)> RakeNotifier::Slack
NameError: uninitialized constant Faraday::Response::Middleware

    class Custom < Faraday::Response::Middleware
                                    ^^^^^^^^^^^^
Did you mean?  Faraday::MiddlewareRegistry
from /tmp/vendor/bundle/ruby/3.1.0/gems/breacan-0.10.0/lib/breacan/response/custom.rb:6:in `<module:Response>'
```

### after this change in this PR
I can use [rake_notification](https://github.com/mizoR/rake_notification).
<img width="751" alt="スクリーンショット 2024-04-15 19 30 17" src="https://github.com/linyows/breacan/assets/50609459/e16e43ec-c03e-4493-90f2-7847f25c00c2">

## How reproduce

When you use faraday v.2 >=.
