### PR TITLE
fix: not publish to GPR when the version is already published

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -3,8 +3,6 @@ name: Ruby Gem
 on:
   push:
     branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -38,7 +38,7 @@ jobs:
           gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
         else
           echo "Gem with the same version already exists. Skipping push..."
-          echo "skip_publish_to_rubygems::true" >> $GITHUB_OUTPUT
+          echo "skip_publish_to_rubygems=true" >> $GITHUB_OUTPUT
         fi
       env:
         GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -31,7 +31,13 @@ jobs:
         chmod 0600 $HOME/.gem/credentials
         printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
         gem build *.gemspec
-        gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+        VERSION=$(gem spec *.gem version | grep version | awk '{print $2}')
+        EXISTS=$(gem search ^breacan$ -a | grep -c $VERSION)
+        if [ $EXISTS -eq 0 ]; then
+          gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+        else
+          echo "Gem with the same version already exists. Skipping push..."
+        fi
       env:
         GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
         OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -25,6 +25,7 @@ jobs:
         ruby-version: 3
 
     - name: Publish to GPR
+      id: gpr
       run: |
         mkdir -p $HOME/.gem
         touch $HOME/.gem/credentials
@@ -37,12 +38,14 @@ jobs:
           gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
         else
           echo "Gem with the same version already exists. Skipping push..."
+          echo "skip_publish_to_rubygems::true" >> $GITHUB_OUTPUT
         fi
       env:
         GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
         OWNER: ${{ github.repository_owner }}
 
     - name: Publish to RubyGems
+      if: ${{ steps.gpr.outputs.skip_publish_to_rubygems != 'true' }}
       run: |
         mkdir -p $HOME/.gem
         touch $HOME/.gem/credentials


### PR DESCRIPTION
SSIA

#### check current gem version
```
$ gem spec *.gem version | grep version | awk '{print $2}'
0.11.0
```

#### check if remote version has been already exists
```
$ gem search ^breacan$ -a | grep -c $VERSION
1

# test. 0.12.0 doesn't exist.
$ gem search ^breacan$ -a | grep -c 0.12.0
0
```